### PR TITLE
Fix spelling error in npm install in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@
 
 # Get started
 
-- NPM: `npm install use-animation-presence`
+- NPM: `npm install use-animate-presence`
 - UMD: https://unpkg.com/use-animate-presence@latest/lib/use-animate-presence.umd.js
 
 # Basic usage


### PR DESCRIPTION
The command listed does not work. 

It should be `npm install use-animate-presence`